### PR TITLE
Allow mesh_node.sh to elevate with sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@ Mesh radio V1.0
 Istall script
   In development
 
+Running the node installer
+-------------------------
+
+The `mesh_node.sh` installer now automatically re-runs itself with
+`sudo` when started by a non-root user. This means you can simply
+execute the script as your regular user and it will prompt for the
+necessary credentials while keeping root access limited to the
+installation process itself.
+
 Configuration script
   To Do
 

--- a/mesh_node.sh
+++ b/mesh_node.sh
@@ -72,12 +72,11 @@ WANT_BRCTL=1
 echo "Check for ROOT."
 
 if [[ $EUID -ne 0 ]]; then
-  echo "Please make sure you are running the script while being root - Cancelling the script."
-  sleep 10
-  exit 1
+  echo "This script needs elevated privileges; re-running with sudo."
+  exec sudo --preserve-env=DEBIAN_FRONTEND "$0" "$@"
 fi
 
-echo "Root check complete."
+echo "Root check complete (running as $(id -un))."
 
 
 #=== Logging ===================================================================


### PR DESCRIPTION
## Summary
- update mesh_node.sh to automatically re-run under sudo when invoked by a non-root user
- document the new behavior so users can run the installer without manually switching to root

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9251dc2208322b683ccf4dc7638d2