### PR TITLE
Restrict MediaMTX download to Raspberry Pi architectures

### DIFF
--- a/mesh_node.sh
+++ b/mesh_node.sh
@@ -750,12 +750,9 @@ case "$ARCH" in
   arm64)
     MEDIAMTX_ARCHIVE=mediamtx_linux_arm64v8.tar.gz
     ;;
-  amd64)
-    MEDIAMTX_ARCHIVE=mediamtx_linux_amd64.tar.gz
-    ;;
   *)
-    warn "Unsupported architecture '$ARCH'; defaulting to amd64 build."
-    MEDIAMTX_ARCHIVE=mediamtx_linux_amd64.tar.gz
+    error "Unsupported architecture '$ARCH'. MediaMTX installation requires Raspberry Pi OS on armhf or arm64. Please rerun this installer on Raspberry Pi OS running on Raspberry Pi hardware."
+    exit 1
     ;;
 esac
 


### PR DESCRIPTION
## Summary
- limit the MediaMTX installer to Raspberry Pi armhf and arm64 architectures
- add an explicit error message instructing operators to rerun the installer on Raspberry Pi OS hardware when the architecture check fails

## Testing
- not run (not on Raspberry Pi hardware)


------
https://chatgpt.com/codex/tasks/task_e_68da9fe335708322be963c669a531575