### PR TITLE
Define Flask service paths and directives

### DIFF
--- a/mesh_node.sh
+++ b/mesh_node.sh
@@ -562,6 +562,21 @@ sleep 10
 
 
 #=== Install Flask ===============================================================
+
+FLASK_APP_DIR="/opt/mesh-flask"
+FLASK_APP_FILE="$FLASK_APP_DIR/app.py"
+FLASK_ENV_DIR="/etc/mesh"
+FLASK_ENV_FILE="$FLASK_ENV_DIR/flask.env"
+FLASK_SERVICE_FILE="/etc/systemd/system/mesh-flask.service"
+
+if [ -z "${TARGET_USER:-}" ] || [ "${TARGET_USER}" = "root" ]; then
+  FLASK_USER_DIRECTIVE="User=root"
+  FLASK_GROUP_DIRECTIVE="Group=root"
+else
+  FLASK_USER_DIRECTIVE="User=$TARGET_USER"
+  FLASK_GROUP_DIRECTIVE="Group=$TARGET_USER"
+fi
+
 info "Installing Flask"
 
 if python3 -m pip show flask >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- define Flask service directory and configuration variables in mesh_node.sh
- set Flask systemd user and group directives with root fallback

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcb2c48c9c83229190cf856c3cb212