### PR TITLE
Add shared mesh stylesheet and link templates

### DIFF
--- a/management.html
+++ b/management.html
@@ -3,65 +3,8 @@
 <head>
     <title>Mesh Monitor - Management</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/mesh.css') }}">
     <style>
-        :root {
-            --background-color: #1a1a1a;
-            --text-color: #ffffff;
-            --card-background: #2d2d2d;
-            --card-inactive: #1a1a1a;
-            --text-inactive: #666666;
-        }
-
-        body {
-            font-family: monospace;
-            margin: 0;
-            padding: 16px;
-            background-color: var(--background-color);
-            color: var(--text-color);
-        }
-
-        .header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 24px;
-        }
-
-        .nav {
-            display: flex;
-            gap: 16px;
-        }
-
-        .nav a {
-            color: var(--text-color);
-            text-decoration: none;
-            padding: 8px 16px;
-            border: 1px solid #444;
-            border-radius: 4px;
-            transition: background-color 0.2s;
-        }
-
-        .nav a:hover {
-            background-color: #444;
-        }
-
-        .nav a.active {
-            background-color: #4caf50;
-            border-color: #4caf50;
-        }
-
-        .section {
-            background-color: var(--card-background);
-            padding: 16px;
-            border-radius: 8px;
-            margin-bottom: 24px;
-        }
-
-        .local-mac {
-            font-size: 14px;
-            color: #999;
-        }
-
         /* Channel Configuration Styles */
         .config-controls {
             display: flex;
@@ -124,22 +67,6 @@
         #reboot-node:disabled {
             background-color: #999;
             cursor: not-allowed;
-        }
-
-        .status-message {
-            padding: 8px;
-            border-radius: 4px;
-            display: none;
-        }
-
-        .status-success {
-            background-color: #4caf50;
-            color: white;
-        }
-
-        .status-error {
-            background-color: #f44336;
-            color: white;
         }
     </style>
     <script>

--- a/static/css/mesh.css
+++ b/static/css/mesh.css
@@ -1,0 +1,73 @@
+:root {
+    --background-color: #1a1a1a;
+    --text-color: #ffffff;
+    --card-background: #2d2d2d;
+    --card-inactive: #1a1a1a;
+    --text-inactive: #666666;
+}
+
+body {
+    font-family: monospace;
+    margin: 0;
+    padding: 16px;
+    background-color: var(--background-color);
+    color: var(--text-color);
+}
+
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 24px;
+}
+
+.nav {
+    display: flex;
+    gap: 16px;
+}
+
+.nav a {
+    color: var(--text-color);
+    text-decoration: none;
+    padding: 8px 16px;
+    border: 1px solid #444;
+    border-radius: 4px;
+    transition: background-color 0.2s;
+}
+
+.nav a:hover {
+    background-color: #444;
+}
+
+.nav a.active {
+    background-color: #4caf50;
+    border-color: #4caf50;
+}
+
+.section {
+    background-color: var(--card-background);
+    padding: 16px;
+    border-radius: 8px;
+    margin-bottom: 24px;
+}
+
+.local-mac {
+    font-size: 14px;
+    color: #999;
+}
+
+.status-message {
+    padding: 8px;
+    border-radius: 4px;
+    display: none;
+}
+
+.status-success {
+    background-color: #4caf50;
+    color: white;
+}
+
+.status-error {
+    background-color: #f44336;
+    color: white;
+}

--- a/wifi.html
+++ b/wifi.html
@@ -3,60 +3,8 @@
 <head>
     <title>Mesh Monitor - WiFi</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/mesh.css') }}">
     <style>
-        :root {
-            --background-color: #1a1a1a;
-            --text-color: #ffffff;
-            --card-background: #2d2d2d;
-            --card-inactive: #1a1a1a;
-            --text-inactive: #666666;
-        }
-
-        body {
-            font-family: monospace;
-            margin: 0;
-            padding: 16px;
-            background-color: var(--background-color);
-            color: var(--text-color);
-        }
-
-        .header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 24px;
-        }
-
-        .nav {
-            display: flex;
-            gap: 16px;
-        }
-
-        .nav a {
-            color: var(--text-color);
-            text-decoration: none;
-            padding: 8px 16px;
-            border: 1px solid #444;
-            border-radius: 4px;
-            transition: background-color 0.2s;
-        }
-
-        .nav a:hover {
-            background-color: #444;
-        }
-
-        .nav a.active {
-            background-color: #4caf50;
-            border-color: #4caf50;
-        }
-
-        .section {
-            background-color: var(--card-background);
-            padding: 16px;
-            border-radius: 8px;
-            margin-bottom: 24px;
-        }
-
         .node-grid {
             display: grid;
             grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
@@ -99,11 +47,6 @@
 
         .status-inactive {
             background-color: #f44336;
-        }
-
-        .local-mac {
-            font-size: 14px;
-            color: #999;
         }
 
         /* Channel Configuration Styles */
@@ -150,22 +93,6 @@
         #apply-channel:disabled {
             background-color: #666;
             cursor: not-allowed;
-        }
-
-        .status-message {
-            padding: 8px;
-            border-radius: 4px;
-            display: none;
-        }
-
-        .status-success {
-            background-color: #4caf50;
-            color: white;
-        }
-
-        .status-error {
-            background-color: #f44336;
-            color: white;
         }
     </style>
     <script>


### PR DESCRIPTION
## Summary
- extract the duplicated mesh UI variables, layout, and navigation rules into `static/css/mesh.css`
- update the WiFi and management templates to use the shared stylesheet while keeping their page-specific overrides

## Testing
- `python -m flask --app app run` *(fails: module 'flask' is not installed and proxy prevents installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68dff2732cfc83228772be8282958005