### PR TITLE
Simplify mesh topology configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,36 +27,7 @@ By default the installer configures:
 * `wlan0` as a stand-alone access point on a separate subnet (`10.0.0.0/24`).
 * `meshctl` as a systemd-managed helper that brings the mesh online on boot.
 
-The new topology extensions make it possible to mix and match multiple connectivity strategies without editing the scripts by hand.
-
-### Wired interfaces inside the mesh backbone
-
-Set `BAT_WIRED_INTERFACES="eth0"` (or a space-separated list) in your `mesh.conf` before running the installer. Every interface listed there is added to `bat0` during `meshctl up`, so wired peers participate in the same Layer 2 domain as the wireless mesh. This is the easiest way to have Ethernet nodes share the mesh broadcast domain.
-
-### Bridging the access point onto the mesh
-
-To make `wlan0` clients appear directly on the mesh, enable bridging:
-
-```ini
-ENABLE_AP_BRIDGE="yes"
-BRIDGE_NAME="br-mesh"
-# Optional: override the management IP assigned to the bridge
-BRIDGE_IP_CIDR="192.168.0.2/24"
-```
-
-When bridging is enabled, `meshctl` automatically creates the Linux bridge, enslaves `bat0` and the access-point interface, applies Spanning Tree (with `BRIDGE_STP=on` by default), and assigns the effective IP address to the bridge. DHCP and DNS services are reconfigured to bind to the bridge so that clients obtain addresses on the mesh network.
-
-### Routed/NAT gateway access point
-
-Leave `ENABLE_AP_BRIDGE="no"` to keep the access point on an isolated subnet. You can still forward traffic into the mesh (or other uplinks) by configuring the new routing controls:
-
-```ini
-AP_ROUTING_MODE="route"      # or "nat"
-AP_ROUTING_PEERS="bat0 eth0" # interfaces that should receive forwarded traffic
-AP_ROUTING_NAT_EGRESS="eth0" # required when AP_ROUTING_MODE=nat
-```
-
-`meshctl` enables IP forwarding when routing is active, installs the necessary `iptables` forwarding rules, and optionally adds a MASQUERADE rule for NAT. Routing and bridging modes are mutually exclusive, and the installer will stop if both are requested at once.
+The mesh backbone is intentionally minimal: `bat0` only enslaves `wlan1`, and the access point remains on its own subnet for management without any bridging or routing glue.
 
 ## Reticulum
 

--- a/mesh.conf
+++ b/mesh.conf
@@ -32,32 +32,3 @@ AP_IP_CIDR="10.0.0.1/24"
 AP_DHCP_RANGE_START="10.0.0.100"
 AP_DHCP_RANGE_END="10.0.0.200"
 AP_DHCP_LEASE="12h"
-
-# ===== Topology extensions =====
-# Space-delimited list of wired interfaces to add to the batman-adv mesh.
-# Example: BAT_WIRED_INTERFACES="eth0 eth1"
-BAT_WIRED_INTERFACES=""
-
-# Bridge the access point directly onto the mesh backbone. When enabled, the
-# access point clients, batman peers, and any wired interfaces that are also
-# bridged will share the same broadcast domain.
-ENABLE_AP_BRIDGE="no"
-BRIDGE_NAME="br-mesh"
-# Assign an address to the bridge when bridging is enabled. Leaving this empty
-# inherits the mesh address specified in IP_CIDR.
-BRIDGE_IP_CIDR=""
-# Enable ("on") or disable ("off") Spanning Tree Protocol on the bridge.
-BRIDGE_STP="on"
-
-# When bridging is disabled, traffic from the access point can still reach the
-# mesh or other uplinks by routing/NAT. Set AP_ROUTING_MODE to one of:
-#   disabled - no routing changes are applied.
-#   route    - only forwarding is enabled between the AP and listed peers.
-#   nat      - forwarding is enabled and a MASQUERADE rule is installed on the
-#              interface specified in AP_ROUTING_NAT_EGRESS.
-AP_ROUTING_MODE="disabled"
-# Space-delimited list of interfaces that should exchange routed traffic with
-# the access point network (for example: "bat0 eth0").
-AP_ROUTING_PEERS="bat0"
-# Interface used for NAT egress when AP_ROUTING_MODE=nat.
-AP_ROUTING_NAT_EGRESS=""


### PR DESCRIPTION
## Summary
- remove bridge, routing, and wired interface options to keep bat0 limited to wlan1
- simplify access point configuration to operate only on its own interface and subnet
- update documentation and example configuration to reflect the streamlined topology

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69219a75ad6c8322b82f98a7f68d02b0)